### PR TITLE
Splits make check into two subtargets

### DIFF
--- a/linkfiles/Makefile
+++ b/linkfiles/Makefile
@@ -4,3 +4,23 @@ include $(COMPONENTS_DIR)/**/tasks/**/Makefile
 check:
 	$(MAKE) lint
 	$(MAKE) test
+
+.PHONY: lint
+lint::
+# Commands that have no potential to execute untrusted code may be run as part of a `lint` target
+# in your component. When adding a `lint` target to your Makefile, ensure that you follow it with 
+# a double-colon like above, so that your target adds to the collection of `lint` commands rather
+# than overriding it for other components.
+
+# This target serves only to ensure that at least one `lint` target exists and should noop.
+	@true
+
+.PHONY: test
+test::
+# Commands that have a potential to execute untrusted code may be run as part of the `test` target.
+# When adding a `test` target to your Makefile, ensure that you follow it with a double-colon like 
+# above, so that your target adds to the collection of `test` commands rather than overriding it 
+# for other components.
+
+# This target serves only to ensure that at least one `test` target exists and should noop.
+	@true

--- a/linkfiles/Makefile
+++ b/linkfiles/Makefile
@@ -1,1 +1,6 @@
 include $(COMPONENTS_DIR)/**/tasks/**/Makefile
+
+.PHONY: check
+check:
+	$(MAKE) lint
+	$(MAKE) test


### PR DESCRIPTION
Adds the `check` target to the platform-level Makefile that pulls in all tasks. This is the only place `check` should be defined.

Adds a `lint` and `test` target with a noop that ensures at least one `lint` and `test` always exist. 

Will be tagged `0.2.0` upon merge.